### PR TITLE
Fix incorrect sizing for canvas when setting the background image

### DIFF
--- a/djaodjin-annotate.js
+++ b/djaodjin-annotate.js
@@ -310,8 +310,7 @@ MIT License
       self.img = new Image();
       self.img.src = image.path;
       self.img.onload = function() {
-        if ((self.options.width && self.options.height) !== undefined ||
-          (self.options.width && self.options.height) !== 0) {
+        if (!self.options.width && !self.options.height) {
           self.currentWidth = this.width;
           self.currentHeight = this.height;
           self.selectImageSize.width = this.width;


### PR DESCRIPTION
Currently using the latest master the height and width provided in the options to annotate is always ignored. If you go to this [jsbin](http://jsbin.com/catoginaki/1/edit?js,console,output) you can see that a height and width is provided but it will log to the console that no width or height was provided.

It looks like the bug was introduced in this commit https://github.com/djaodjin/djaodjin-annotate/commit/36080d94d033f53ebff3f77808e90c7fa264b067